### PR TITLE
Fix :focus-visible in safari

### DIFF
--- a/src/hooks/useBrowserName.tsx
+++ b/src/hooks/useBrowserName.tsx
@@ -1,0 +1,42 @@
+import { useRef, useEffect } from 'react';
+
+const useBrowserName = () => {
+  // to prevent rerendering, because it's imposible to change browser while using app
+  const browserName = useRef('');
+
+  useEffect(() => {
+    let sBrowser,
+      sUsrAg = navigator.userAgent;
+
+    if (sUsrAg.indexOf('Firefox') > -1) {
+      sBrowser = 'Mozilla Firefox';
+      // "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
+    } else if (sUsrAg.indexOf('SamsungBrowser') > -1) {
+      sBrowser = 'Samsung Internet';
+      // "Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G955F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36
+    } else if (sUsrAg.indexOf('Opera') > -1 || sUsrAg.indexOf('OPR') > -1) {
+      sBrowser = 'Opera';
+      // "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 OPR/57.0.3098.106"
+    } else if (sUsrAg.indexOf('Trident') > -1) {
+      sBrowser = 'Microsoft Internet Explorer';
+      // "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Zoom 3.6.0; wbx 1.0.0; rv:11.0) like Gecko"
+    } else if (sUsrAg.indexOf('Edge') > -1) {
+      sBrowser = 'Microsoft Edge';
+      // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"
+    } else if (sUsrAg.indexOf('Chrome') > -1) {
+      sBrowser = 'Google Chrome or Chromium';
+      // "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/66.0.3359.181 Chrome/66.0.3359.181 Safari/537.36"
+    } else if (sUsrAg.indexOf('Safari') > -1) {
+      sBrowser = 'Apple Safari';
+      // "Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1 980x1306"
+    } else {
+      sBrowser = 'unknown';
+    }
+
+    browserName.current = sBrowser;
+  }, []);
+
+  return browserName.current;
+};
+
+export default useBrowserName;

--- a/src/routes/Game/Game.tsx
+++ b/src/routes/Game/Game.tsx
@@ -15,9 +15,12 @@ import { QUESTIONS_URL } from '../../utils/constsants';
 import { ScoreContext } from '../../contexts/ScoreContext';
 
 import './Game.scss';
+import useBrowserName from '../../hooks/useBrowserName';
 
 const Game = (): JSX.Element => {
   const navigate = useNavigate();
+  const browserName = useBrowserName();
+
   const [isPlaying, setIsPlaying] = useState(true);
 
   // custom hook for better testability and readability
@@ -67,12 +70,15 @@ const Game = (): JSX.Element => {
     <section className="game-page">
       <h2 className="game-page__header">{normalizedQuestion}</h2>
 
-      <ul tabIndex={1} className="game-page__words-list">
+      <ul
+        tabIndex={browserName !== 'Apple Safari' ? 1 : NaN}
+        className="game-page__words-list"
+      >
         {normalizedWords?.map(function renderWords(word, index) {
           const { id, value, className } = word;
           return (
             <li
-              tabIndex={index + 2}
+              tabIndex={browserName !== 'Apple Safari' ? index + 2 : NaN}
               className={className}
               key={id}
               onClick={() => toggleWordSelection(id)}

--- a/src/routes/Home/Home.scss
+++ b/src/routes/Home/Home.scss
@@ -22,6 +22,9 @@
     border: 1px solid var(--color-accent-light);
     border-radius: 4px;
     padding: 0.75rem;
-    outline-color: var(--color-primary);
+
+    &:focus {
+      outline: 1px solid var(--color-primary);
+    }
   }
 }


### PR DESCRIPTION
Safari has issues with the ":focus-visible" pseudo-class, and for now, there is no available workaround. This is why I decided to remove the ability to focus on words on the "Game" route in Safari.